### PR TITLE
add UA string, add ssl verify optional flag

### DIFF
--- a/securityheaders.py
+++ b/securityheaders.py
@@ -22,6 +22,17 @@ class UnableToConnect(SecurityHeadersException):
 
 
 class SecurityHeaders():
+    # Let's try to imitate a legit browser to avoid being blocked / flagged as web crawler
+    REQUEST_HEADERS = {
+        'Accept': ('text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,'
+                   'application/signed-exchange;v=b3;q=0.9'),
+        'Accept-Encoding': 'gzip, deflate, br',
+        'Accept-Language': 'en-GB,en;q=0.9',
+        'Cache-Control': 'max-age=0',
+        'User-Agent': ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)'
+                       'Chrome/106.0.0.0 Safari/537.36'),
+    }
+
     HEADERS_DICT = {
         'x-frame-options': {
             'recommended': True,
@@ -62,7 +73,7 @@ class SecurityHeaders():
         }
     }
 
-    def __init__(self, url, max_redirects=2):
+    def __init__(self, url, max_redirects=2, no_check_certificate=False):
         parsed = urlparse(url)
         if not parsed.scheme and not parsed.netloc:
             url = "{}://{}".format(DEFAULT_URL_SCHEME, url)
@@ -74,6 +85,7 @@ class SecurityHeaders():
         self.hostname = parsed.netloc
         self.path = parsed.path
         self.max_redirects = max_redirects
+        self.verify_ssl = False if no_check_certificate else True
         self.headers = None
 
     def test_https(self):
@@ -90,36 +102,27 @@ class SecurityHeaders():
     def _follow_redirect_until_response(self, url, follow_redirects=5):
         temp_url = urlparse(url)
         while follow_redirects >= 0:
-            sslerror = False
             if not temp_url.netloc:
                 raise InvalidTargetURL("Invalid redirect URL")
 
             if temp_url.scheme == 'http':
                 conn = http.client.HTTPConnection(temp_url.netloc, timeout=10)
             elif temp_url.scheme == 'https':
-                ctx = ssl._create_stdlib_context()
+                if self.verify_ssl:
+                    ctx = ssl.create_default_context()
+                else:
+                    ctx = ssl._create_stdlib_context()
                 conn = http.client.HTTPSConnection(temp_url.netloc, context=ctx, timeout=10)
             else:
                 raise InvalidTargetURL("Unsupported protocol scheme")
 
             try:
-                conn.request('HEAD', temp_url.path)
+                conn.request('GET', temp_url.path, headers=self.REQUEST_HEADERS)
                 res = conn.getresponse()
-                if temp_url.scheme == 'https':
-                    sslerror = False
             except (socket.gaierror, socket.timeout, ConnectionRefusedError) as e:
                 raise UnableToConnect("Connection failed {}".format(temp_url.netloc)) from e
-            except ssl.SSLError:
-                sslerror = True
-
-            # If SSL error, retry without verifying the certificate chain
-            if sslerror:
-                conn = http.client.HTTPSConnection(temp_url.netloc, timeout=10, context=ssl._create_stdlib_context())
-                try:
-                    conn.request('HEAD', temp_url.path)
-                    res = conn.getresponse()
-                except (socket.gaierror, socket.timeout, ConnectionRefusedError, ssl.SSLError) as e:
-                    raise UnableToConnect("Connection failed {}".format(temp_url.netloc)) from e
+            except ssl.SSLError as e:
+                raise UnableToConnect("SSL Error") from e
 
             if res.status >= 300 and res.status < 400:
                 headers = res.getheaders()
@@ -156,14 +159,16 @@ class SecurityHeaders():
         if target_url.scheme == 'http':
             conn = http.client.HTTPConnection(target_url.hostname, timeout=10)
         elif target_url.scheme == 'https':
-            # Don't verify certs here - we're interested in headers, HTTPS is checked separately
-            ctx = ssl._create_stdlib_context()
+            if self.verify_ssl:
+                ctx = ssl.create_default_context()
+            else:
+                ctx = ssl._create_stdlib_context()
             conn = http.client.HTTPSConnection(target_url.hostname, context=ctx, timeout=10)
         else:
             raise InvalidTargetURL("Unsupported protocol scheme")
 
         try:
-            conn.request('HEAD', target_url.path)
+            conn.request('GET', target_url.path, headers=self.REQUEST_HEADERS)
             res = conn.getresponse()
         except (socket.gaierror, socket.timeout, ConnectionRefusedError, ssl.SSLError) as e:
             raise UnableToConnect("Connection failed {}".format(target_url.hostname)) from e
@@ -199,8 +204,10 @@ if __name__ == "__main__":
     parser.add_argument('url', metavar='URL', type=str, help='Target URL')
     parser.add_argument('--max-redirects', dest='max_redirects', metavar='N', default=2, type=int,
                         help='Max redirects, set 0 to disable')
+    parser.add_argument('--no-check-certificate', dest='no_check_certificate', action='store_true',
+                        help='Do not verify TLS certificate chain')
     args = parser.parse_args()
-    header_check = SecurityHeaders(args.url, args.max_redirects)
+    header_check = SecurityHeaders(args.url, args.max_redirects, args.no_check_certificate)
     header_check.fetch_headers()
     headers = header_check.check_headers()
     if not headers:


### PR DESCRIPTION
* Add UA string and other common request headers to try to avoid bot filters
* Make TLS certificate chain verification optional with argument `--no-check-certificate`
