### PR TITLE
allow combined headers in certain cases

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,6 @@
 # If no URL scheme defined, what to use by default
 DEFAULT_URL_SCHEME = 'https'
+DEFAULT_TIMEOUT = 10
 
 EVAL_WARN = 0
 EVAL_OK = 1


### PR DESCRIPTION
Comply with RFC 2616 section 4.2

> Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma. The order in which header fields with the same field-name are received is therefore significant to the interpretation of the combined field value, and thus a proxy MUST NOT change the order of these field values when a message is forwarded.
